### PR TITLE
Fix install and description with PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
+import os
 from distutils.core import setup
 from layouter import __version__
+
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
@@ -29,6 +33,7 @@ setup(
     packages=['layouter'],
     version=__version__,
     description='Grid system for Django-CMS users which aims for ease of use.',
+    long_description = read('README.rst'),
     author='Robert Stein',
     author_email='robert@blueshoe.de',
     url='https://github.com/Blueshoe/djangocms-layouter',

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     version=__version__,
     description='Grid system for Django-CMS users which aims for ease of use.',
     long_description = read('README.rst'),
+    license = read('LICENSE.txt'),
     author='Robert Stein',
     author_email='robert@blueshoe.de',
     url='https://github.com/Blueshoe/djangocms-layouter',


### PR DESCRIPTION
Use the content of README.rst to PyPi's _long_description_. 

I expect it to be rendered nicely; if it doesn't, it's probably due to our use of _image::_ in the readme which seems to provide trouble on GitHub as well.
I didn't test it on PyPi, but it is taken from https://github.com/divio/django-filer/blob/develop/setup.py where it seems to work fine. 