### PR TITLE
Add MANIFEST template to fix distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include LICENSE.txt
+include README.rst
+# recursive-include layouter/locale *
+recursive-include layouter/statics *
+recursive-include layouter/templates *


### PR DESCRIPTION
By using this manifest template the _sdist_ command will bundle all necessary files when building the distribution. 

Before, some files were missing, like the README.rst, the statics and the templates

I tested that this fixes the problem by uploading a test-package to the pypitest index via:
`python setup.py sdist upload -r pypitest`

Fixes #5
Reference: https://docs.python.org/2/distutils/sourcedist.html#specifying-the-files-to-distribute