### PR TITLE
Fix install via pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,4 +42,6 @@ setup(
     install_requires=REQUIREMENTS,
     keywords=['django', 'Django CMS', 'grid', 'bootstrap', 'website', 'CMS', 'Blueshoe'],
     classifiers=CLASSIFIERS,
+    include_package_data=True,
+    zip_safe=False,
 )


### PR DESCRIPTION
include_package_data needs to be set to True, otherwise setuptools seem to ignore the manifest template when installing it