### PR TITLE
Add option for making the columns the same height

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,8 +36,8 @@ These are the core features of **Django-CMS Layouter**:
 * Flat tree in structure mode
 * Automatic arrangement of columns, for different screen sizes
 * Warning, due to too many plugins, in structure mode
+* Optional equal height for columns
 * Toggle grid - show and hide grid in content mode
-
 
 ToDo's
 ------

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,9 @@ Installation and Configuration
 * Run migrations: ``python manage.py migrate layouter``.
 * Done.
 
+Please note: Migrations are generated each release. If you checkout the current state of development
+migrations might be missing.
+
 Features
 --------
 

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ These are the core features of **Django-CMS Layouter**:
 * Flat tree in structure mode
 * Automatic arrangement of columns, for different screen sizes
 * Warning, due to too many plugins, in structure mode
-* Optional equal height for columns
+* Optional equal height for columns (uses CSS3 flexbox)
 * Toggle grid - show and hide grid in content mode
 
 ToDo's

--- a/layouter/cms_plugins.py
+++ b/layouter/cms_plugins.py
@@ -17,7 +17,7 @@ class ContainerCMSPlugin(CMSPluginBase):
 
     fieldsets = (
         (None, {
-            'fields': ('container_type', 'margin')
+            'fields': ('container_type', 'margin', 'equal_height')
         }),
         (_('Advanced'), {
             'classes': ('collapse',),

--- a/layouter/models.py
+++ b/layouter/models.py
@@ -62,6 +62,7 @@ class ContainerPlugin(CMSPlugin):
 
     margin = models.IntegerField(choices=MARGIN_TYPES, null=False, blank=False, default=MARGIN_TYPES[0][0],
                                  help_text=_('How much margin is needed on the left and right side?'))
+    equal_height = models.BooleanField(_('Make height of the columns equal'), null=False, blank=False, default=False)
 
     css_classes = models.CharField(max_length=512, blank=True, null=True)
 

--- a/layouter/models.py
+++ b/layouter/models.py
@@ -62,7 +62,12 @@ class ContainerPlugin(CMSPlugin):
 
     margin = models.IntegerField(choices=MARGIN_TYPES, null=False, blank=False, default=MARGIN_TYPES[0][0],
                                  help_text=_('How much margin is needed on the left and right side?'))
-    equal_height = models.BooleanField(_('Make height of the columns equal'), null=False, blank=False, default=False)
+
+    # To achieve same height columns we use the CSS3 flex box grid. For more information about it have a look at
+    # http://caniuse.com/flexbox
+    equal_height = models.BooleanField(_('Align height of all columns in this row. Please note: This setting is not '
+                                         'supported by Internet Explorer 9 and below.'), null=False, blank=False,
+                                       default=False)
 
     css_classes = models.CharField(max_length=512, blank=True, null=True)
 

--- a/layouter/static/layouter/css/layouter.css
+++ b/layouter/static/layouter/css/layouter.css
@@ -70,4 +70,9 @@
 .full-width:before {
   content: "\e906";
 }
-
+.layouterRow--equalHeight {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}

--- a/layouter/templates/layouter/container.html
+++ b/layouter/templates/layouter/container.html
@@ -2,7 +2,10 @@
 {% load staticfiles %}
 <div class="row layouterRow--outer">
     <div class="col-md-offset-{{ instance.margin }} col-md-{{ width }}">
-        <div class="row layouterRow--inner {% if request.session.layouter_grid %}show-grid{% endif %} {{ instance.css_classes }}">
+        <div class="row layouterRow--inner
+        {% if request.session.layouter_grid %}show-grid{% endif %}
+        {% if instance.equal_height %}layouterRow--equalHeight{% endif %}
+        {{ instance.css_classes }}">
             {% include 'layouter/partials/one_col.html' %}
             {% include 'layouter/partials/two_cols.html' %}
             {% include 'layouter/partials/three_cols.html' %}


### PR DESCRIPTION
This PR adds a simple checkbox to allow the user to set the height of the columns to the same height. It is done using Flexbox.

Tested with:
- Desktop Chrome
- Desktop Firefox


![equal-height](https://cloud.githubusercontent.com/assets/3121306/25858718/b2599064-34dc-11e7-92f3-55a11a8b9597.png)

Related issue #13