### PR TITLE
Prevent text-selection when clicking on the container types

### DIFF
--- a/layouter/static/layouter/css/layouter.css
+++ b/layouter/static/layouter/css/layouter.css
@@ -37,6 +37,7 @@
   text-align: center;
   border: 0;
   padding-bottom: 15px;
+  user-select: none;
 }
 #id_container_type li span {
   padding-bottom: 7px;


### PR DESCRIPTION
This change prevents this annoying occurence which drove me crazy :see_no_evil: :grin: 
![user-selection](https://cloud.githubusercontent.com/assets/3121306/25858980/799bcf2a-34dd-11e7-808e-1cd1b79365da.png)
