### PR TITLE
Fix wrong width for slick slider in layouter row

### DIFF
--- a/layouter/static/layouter/css/layouter.css
+++ b/layouter/static/layouter/css/layouter.css
@@ -31,6 +31,10 @@
   border: 2px dashed #1F5E8E;
   margin-bottom: -4px;
 }
+.layouterRow--inner > * {
+    min-height: 0;
+    min-width: 0;
+}
 #id_container_type li {
   display: inline-block;
   width: 250px;


### PR DESCRIPTION
Using the [slick slider](http://kenwheeler.github.io/slick/) in a layouter row caused the slider width to be not correctly calculated.
The issue is flexbox, as described here: https://stackoverflow.com/a/26916542/2607135