### PR TITLE
Django 3.1 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,11 @@ env:
   - TOX_ENV=py37-dj22-cms35
   - TOX_ENV=py37-dj22-cms36
   - TOX_ENV=py37-dj22-cms37
+  # Django 3.1
+  - TOX_ENV=py37-dj31-cms37
+  - TOX_ENV=py37-dj31-cms38
+  - TOX_ENV=py38-dj31-cms37
+  - TOX_ENV=py38-dj31-cms38
 
 install:
   - pip install tox coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,32 +5,16 @@ branches: master  # This way push builds will only run on master branch. Does no
 
 env:
   - TOX_ENV=flake8
-  - TOX_ENV=py34-latest
-  - TOX_ENV=py37-latest
-  # Django 2
-  - TOX_ENV=py34-dj2-cms35
-  - TOX_ENV=py34-dj2-cms36
-  - TOX_ENV=py34-dj2-cms37
-  - TOX_ENV=py37-dj2-cms35
-  - TOX_ENV=py37-dj2-cms36
-  - TOX_ENV=py37-dj2-cms37
-  # Django 2.1
-  - TOX_ENV=py34-dj21-cms35
-  - TOX_ENV=py34-dj21-cms36
-  - TOX_ENV=py34-dj21-cms37
-  - TOX_ENV=py37-dj21-cms35
-  - TOX_ENV=py37-dj21-cms36
-  - TOX_ENV=py37-dj21-cms37
+  - TOX_ENV=py35-latest
+  - TOX_ENV=py38-latest
   # Django 2.2
-  - TOX_ENV=py34-dj22-cms35
-  - TOX_ENV=py34-dj22-cms36
-  - TOX_ENV=py34-dj22-cms37
-  - TOX_ENV=py37-dj22-cms35
-  - TOX_ENV=py37-dj22-cms36
+  - TOX_ENV=py35-dj22-cms37
+  - TOX_ENV=py35-dj22-cms37
+  - TOX_ENV=py37-dj22-cms37
   - TOX_ENV=py37-dj22-cms37
   # Django 3.1
-  - TOX_ENV=py37-dj31-cms37
-  - TOX_ENV=py37-dj31-cms38
+  - TOX_ENV=py36-dj31-cms37
+  - TOX_ENV=py36-dj31-cms38
   - TOX_ENV=py38-dj31-cms37
   - TOX_ENV=py38-dj31-cms38
 

--- a/layouter/models.py
+++ b/layouter/models.py
@@ -5,12 +5,11 @@ from django.db import models
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 from cms.models.pluginmodel import CMSPlugin
-from django.utils.encoding import python_2_unicode_compatible, force_text
+from django.utils.encoding import force_text
 from easy_thumbnails.files import get_thumbnailer
 from filer.fields.image import FilerImageField
 
 
-@python_2_unicode_compatible
 class ContainerPlugin(CMSPlugin):
 
     FULL_WIDTH = 100

--- a/layouter/templates/layouter/change_form.html
+++ b/layouter/templates/layouter/change_form.html
@@ -1,5 +1,5 @@
 {% extends 'admin/cms/extensions/change_form.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block extrastyle %}
     {{ block.super }}

--- a/layouter/templates/layouter/partials/layouter_javascript.html
+++ b/layouter/templates/layouter/partials/layouter_javascript.html
@@ -1,4 +1,4 @@
-{% load sekizai_tags staticfiles %}
+{% load sekizai_tags static %}
 
 {# The following JavaScript and Styles are only needed in editing mode. #}
 {% if request.toolbar.edit_mode %}

--- a/layouter/urls.py
+++ b/layouter/urls.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from django.conf.urls import url
+from django.urls import re_path
 
 from layouter.views import ToggleGridView
 
+
+app_name = 'layouter'
+
+
 urlpatterns = [
-    url(r'^toggle-grid/', ToggleGridView.as_view(), name='toggle-grid')
+    re_path(r'^toggle-grid/', ToggleGridView.as_view(), name='toggle-grid')
 ]

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'Topic :: Internet :: WWW/HTTP',
     'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     'Topic :: Software Development :: Libraries :: Python Modules',

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,9 @@
 [tox]
 envlist =
     flake8
-    py{35,37}-latest
-    py{35,37}-dj2-cms{36,37}
-    py{35,37}-dj21-cms{36,37}
-    py{35,37}-dj22-cms{36,37}
-    py{37,38}-dj31-cms{37,38}
+    py{35,38}-latest
+    py{35,37}-dj22-cms{37}
+    py{36,38}-dj31-cms{37,38}
 
 
 skip_missing_interpreters=False
@@ -14,12 +12,9 @@ skip_missing_interpreters=False
 [testenv]
 deps =
     -r{toxinidir}/tests/requirements.txt
-    dj2: Django>=2,<2.1
-    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<3
     dj31: Django>=3.1,<3.2
     latest: django-cms
-    cms35: django-cms>=3.5,<3.6
     cms36: django-cms>=3.6,<3.7
     cms37: django-cms>=3.7,<3.8
     cms38: django-cms>=3.8rc1,<3.9

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,14 @@
 [tox]
 envlist =
     flake8
-    py{34,37}-latest
-    py{34,37}-dj2-cms{35,36,37}
-    py{34,37}-dj21-cms{35,36,37}
-    py{34,37}-dj22-cms{35,36,37}
+    py{35,37}-latest
+    py{35,37}-dj2-cms{36,37}
+    py{35,37}-dj21-cms{36,37}
+    py{35,37}-dj22-cms{36,37}
+    py{37,38}-dj31-cms{37,38}
 
-skip_missing_interpreters=True
+
+skip_missing_interpreters=False
 
 
 [testenv]
@@ -15,10 +17,12 @@ deps =
     dj2: Django>=2,<2.1
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<3
+    dj31: Django>=3.1,<3.2
     latest: django-cms
     cms35: django-cms>=3.5,<3.6
     cms36: django-cms>=3.6,<3.7
     cms37: django-cms>=3.7,<3.8
+    cms38: django-cms>=3.8rc1,<3.9
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase


### PR DESCRIPTION
Solves #38 

I have also removed tox and travis envs that are not supported any more (Python 3.4 and Django 2.0 and 2.1). Tox was failing with Django < 2.2 anyways, apparently there are some compatibility issues with sekizai and some other packages which get installed as secondary dependencies...